### PR TITLE
更新國家名稱

### DIFF
--- a/dict/chewing/alt.csv
+++ b/dict/chewing/alt.csv
@@ -2,7 +2,8 @@
 # dc:rights,Copyright (c) 2025 libchewing Core Team,
 # dc:license,LGPL-2.1-or-later,
 # dc:identifier,2025.8.14,
+參與,27761,ㄘㄢ ㄩˇ
+柬埔寨,285,ㄐㄧㄢˇ ㄅㄨˇ ㄓㄞˋ
 鑰匙,668,ㄧㄠˋ ㄔˊ
 鑰匙圈,215,ㄧㄠˋ ㄔˊ ㄑㄩㄢ
 鑰匙孔,25,ㄧㄠˋ ㄔˊ ㄎㄨㄥˇ
-參與,27761,ㄘㄢ ㄩˇ


### PR DESCRIPTION
- 新增語詞
    - 補全尚未輸入的國家名稱，資料來源：[外交部各國中英文名稱對照表 ](https://www.mofa.gov.tw/News_Content.aspx?n=491&s=85015)

- 刪除未使用語詞
    - 快娶,100,ㄎㄨㄞˋ ㄑㄩˇ
    
- 移入錯誤注音到 alt.csv
    - 柬埔寨,285,ㄐㄧㄢˇ ㄅㄨˇ ㄓㄞˋ
    